### PR TITLE
Enum for operations; Gifts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test_local:
 	curl -F taxdoc=@testdata/synthetic_coinbase_csv.csv "${URL}/taxdocs?exchange=coinbase&user_id=1"
 	curl -F taxdoc=@testdata/synthetic_gemini_csv.csv "${URL}/taxdocs?exchange=gemini&user_id=1"
 	curl -X POST localhost:5000/yabc/v1/run_basis?user_id=1 | grep success
-	curl localhost:5000/yabc/v1/download_8949/2008?user_id=1 | grep 14564
+	curl localhost:5000/yabc/v1/download_8949/2008?user_id=1 | grep 14765
 
 test_buyone_sellone:
 	curl -F taxdoc=@testdata/synthetic_buyone_sellone_coinbase.csv \

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -37,7 +37,7 @@ def split_coin_to_add(coin_to_split, amount, trans):
     to_add = copy.deepcopy(coin_to_split)
     to_add.quantity = split_amount_back_in_pool
     to_add.fee = split_fee_back_in_pool
-    to_add.operation = "Split"
+    to_add.operation = Transaction.Operation.SPLIT
     assert to_add.quantity > 0
     return to_add
 

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -3,9 +3,6 @@ Calculating the cost basis.
 
 TODO: Add other accounting methods than FIFO, most notably LIFO.
 """
-
-__author__ = "Robert Karl <robertkarljr@gmail.com>"
-
 import copy
 import csv
 import io
@@ -15,6 +12,9 @@ from typing import Sequence
 from yabc import csv_to_json
 from yabc import transaction
 from yabc.costbasisreport import CostBasisReport
+from yabc.transaction import Transaction
+
+__author__ = "Robert Karl <robertkarljr@gmail.com>"
 
 
 def split_coin_to_add(coin_to_split, amount, trans):
@@ -114,7 +114,7 @@ def process_one(trans, pool):
     amount = Decimal(0)
     pool_index = -1
 
-    if trans.operation == "Buy":
+    if trans.operation == Transaction.Operation.BUY:
         return {"basis_reports": [], "add": trans, "remove_index": -1}
 
     while amount < trans.quantity:
@@ -134,6 +134,21 @@ def process_one(trans, pool):
     needs_remove = pool_index
     if not needs_split:
         pool_index += 1  # Ensures that we report the oldest transaction as a sale.
+    if trans.operation == Transaction.Operation.SELL:
+        # The other option is gift. If it's a gift we don't report any gain or loss.
+        # The coins just magically remove themselves from the pool.
+        # No entry in 8949 for them.
+        cost_basis_reports.extend(_build_sale_reports(pool, pool_index, trans))
+
+    return {
+        "basis_reports": cost_basis_reports,
+        "add": to_add,
+        "remove_index": needs_remove,
+    }
+
+
+def _build_sale_reports(pool, pool_index, trans):
+    ans = []
     for i in range(pool_index):
         # each of these including pool_index will become a sale to be reported to IRS
         # The cost basis is pool[i].proceeds
@@ -151,13 +166,8 @@ def process_one(trans, pool):
             trans.date,
             pool[i].asset_name,
         )
-        cost_basis_reports.append(ir)
-
-    return {
-        "basis_reports": cost_basis_reports,
-        "add": to_add,
-        "remove_index": needs_remove,
-    }
+        ans.append(ir)
+    return ans
 
 
 def transactions_from_file(tx_file, expected_format):
@@ -236,39 +246,10 @@ def process_all_fifo(txs):
         if to_add is not None:
             # This is where FIFO is defined: put the BUY transactions at the end.
             # For split coins, they need to be sold first.
-            if to_add.operation == "Buy":
+            if to_add.operation == Transaction.Operation.BUY:
                 pool.append(to_add)
             else:
-                assert to_add.operation == "Split"
+                assert to_add.operation == Transaction.Operation.SPLIT
                 pool.insert(0, to_add)
         irs_reports.extend(reports)
     return irs_reports
-
-
-def run_basis(pool, transactions, method, userid, tax_year):
-    """
-    Where the magic happens.
-
-    Requirements:
-        - pool is a sequence of purchases or splits (no sales).
-        - Each element in pool needs to have a `purchase date` before
-          `tax_year` begins.
-        - txs should have at least one 'sale' within tax_year and zero sale txs
-          before tax_year.
-    """
-    supported_methods = ["FIFO"]
-    if not method in supported_methods:
-        raise ValueError("Accounting method {} not supported".format(method))
-    for tx in pool:
-        assert tx.operation == "Split" or tx.operation == "Buy"
-    asset_names = set(
-        [i.asset_name for i in txs]
-    )  # We can safely ignore pool's contents
-    reports = []
-    for asset in asset_names:
-        txs = []
-        filter_by_asset = lambda x: x.asset_name == asset
-        txs.extend(filter(filter_by_asset, pool))
-        txs.extend(filter(filter_by_asset, transactions))
-        reports.extend(process_all(method, txs))
-    return reports

--- a/src/yabc/server/sql_backend.py
+++ b/src/yabc/server/sql_backend.py
@@ -133,6 +133,7 @@ class SqlBackend:
             ans.append(tx_dict)
             for numeric_key in ("usd_subtotal", "fees", "quantity"):
                 tx_dict[numeric_key] = str(tx_dict[numeric_key])
+            tx_dict["operation"] = tx_dict["operation"].value
         for item in ans:
             item["date"] = str(item["date"])
         return json.dumps(ans)

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -172,9 +172,9 @@ class Transaction(yabc.Base):
 def make_transaction(kind: Transaction.Operation, quantity, fees, subtotal):
     sample_date = datetime.datetime(2015, 2, 5, 6, 27, 56, 373000)
     return Transaction(
+        "BTC",
         date=sample_date,
         operation=kind,
-        asset_name="BTC",
         fees=fees,
         quantity=quantity,
         usd_subtotal=subtotal,

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -169,13 +169,14 @@ class Transaction(yabc.Base):
         )
 
 
-def make_transaction(kind: Transaction.Operation, quantity, fees, subtotal):
-    sample_date = datetime.datetime(2015, 2, 5, 6, 27, 56, 373000)
+def make_transaction(kind: Transaction.Operation, quantity, fees, subtotal, date=datetime.datetime(2015, 2, 5, 6, 27, 56, 373000)):
     return Transaction(
         "BTC",
-        date=sample_date,
+        date=date,
         operation=kind,
         fees=fees,
         quantity=quantity,
         usd_subtotal=subtotal,
     )
+
+Operation = Transaction.Operation

--- a/tests/fifo_test.py
+++ b/tests/fifo_test.py
@@ -1,0 +1,36 @@
+import unittest
+
+from yabc.basis import process_all_fifo
+from yabc.transaction import *
+
+class FifoTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.start = datetime.datetime.now()
+        self.one_day = datetime.timedelta(1)
+        self.purchase = make_transaction(Operation.BUY, 2, 0, 2000, date=self.start)
+
+    def test_zero_gains(self):
+        sale1 = make_transaction(Operation.SELL, 1, 0, 1000, date = self.start + self.one_day)
+        sale2 = make_transaction(Operation.SELL, 1, 0, 1000, date = self.start + self.one_day * 2)
+        reports = process_all_fifo([self.purchase, sale1, sale2])
+        self.assertEqual(len(reports), 2)
+        for i in reports:
+            self.assertEqual(i.gain_or_loss, 0)
+
+    def test_zero_gains_with_sale_fees(self):
+        sale1 = make_transaction(Operation.SELL, 1, 10, 1010, date = self.start + self.one_day)
+        sale2 = make_transaction(Operation.SELL, 1, 10, 1010, date = self.start + self.one_day * 2)
+        reports = process_all_fifo([self.purchase, sale1, sale2])
+        self.assertEqual(len(reports), 2)
+        for i in reports:
+            self.assertEqual(i.gain_or_loss, 0)
+
+    def test_zero_gains_with_buy_fees(self):
+        purchase_with_fees = make_transaction(Operation.BUY, 2, 20, 2000, date=self.start)
+        sale1 = make_transaction(Operation.SELL, 1, 0, 1010, date = self.start + self.one_day)
+        sale2 = make_transaction(Operation.SELL, 1, 0, 1010, date = self.start + self.one_day * 2)
+        reports = process_all_fifo([purchase_with_fees, sale1, sale2])
+        self.assertEqual(len(reports), 2)
+        for i in reports:
+            print(i)
+            self.assertEqual(i.gain_or_loss, 0)

--- a/tests/gifts_test.py
+++ b/tests/gifts_test.py
@@ -1,0 +1,18 @@
+import unittest
+
+from yabc.basis import process_all_fifo
+from yabc.transaction import *
+
+class GiftsTest(unittest.TestCase):
+    def test_gifts(self):
+        start = datetime.datetime.now()
+        one_day = datetime.timedelta(1)
+        purchase = make_transaction(Operation.BUY, 2, 0, 2000, date=start)
+        gift_given = make_transaction(Operation.GIFT, 1, 0, 0, date=start + one_day)
+        # should trigger a short term gain of $1
+        sale = make_transaction(Operation.SELL, 1, 0, 1001, date = start + one_day * 2)
+        reports = process_all_fifo([purchase, gift_given, sale])
+        print(reports)
+        self.assertEqual(len(reports), 1)
+        sale_report = reports[0]
+        self.assertEqual(sale_report.gain_or_loss, Decimal('1'))


### PR DESCRIPTION
- Add an enum. No DB change, they will be serialized to enum and back going to the database.
- Introduce the Gift operation type. When a trader gives a gift, no taxable event is triggered but we need to remove the coins from the pool.

Fixes for 3 bugs related to basis.
- During a coin split, purchase fees were being calculated but not saved due to instance variable `fees` vs `fee` being used. This would have impacted coins added back to the pool with the incorrect basis.
- subtotal for coins added back to the pool was incorrect. This makes basis correct for coins added back to the pool on the asset purchase price side.
- Needed to make gifts triggering a split NOT insert a cost basis report.

# Test plan
integration and unit tests