### PR TITLE
Add CoinPool class.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import setuptools
 
 setuptools.setup(
-    version="0.1.8",
+    version="0.1.9",
     name="yabc",
     python_requires=">=3.5,<3.8",
     author="Seattle Blockchain Solutions",

--- a/src/yabc/__main__.py
+++ b/src/yabc/__main__.py
@@ -32,7 +32,7 @@ def main():
             print(flag, file=sys.stderr)
         print("Quitting yabc.", file=sys.stderr)
         sys.exit(1)
-    processor = basis.BasisProcessor("FIFO", parser.txs)
+    processor = basis.BasisProcessor(coinpool.PoolMethod.FIFO, parser.txs)
     reports = processor.process()
     batch = ReportBatch(reports)
     print(batch.human_readable_report())

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -25,7 +25,7 @@ def split_coin_to_add(coin_to_split, amount, trans):
     Create a coin to be added back to the pool.
 
     TODO: For creating an audit trail, we should track the origin of the split coin,
-    ie. was it generated from mining or a gift or just purchased?
+          ie. was it generated from mining, a gift, or purchased?
     
     parameters:
         amount: unsold portion of the asset ie. float(0.5) for a sale of 1 BTC
@@ -156,7 +156,7 @@ def process_one(trans: transaction.Transaction, pool: coinpool.CoinPool):
     return (cost_basis_reports, diff)
 
 
-def _build_sale_reports(pool, pool_index, trans: Transaction):
+def _build_sale_reports(pool: coinpool.CoinPool, pool_index, trans: Transaction):
     ans = []
     for i in range(pool_index):
         # each of these including pool_index will become a sale to be reported to IRS
@@ -220,7 +220,7 @@ def reports_to_csv(reports: Sequence[CostBasisReport]):
     return of
 
 
-def _process_all(method: coinpool.PoolMethod, txs):
+def _process_all(method: coinpool.PoolMethod, txs: Sequence[Transaction]):
     """
     The meat and potatoes. Creates a transaction pool, and iteratively processes txs and saves the pool state and any
     cost basis reports.
@@ -240,7 +240,11 @@ def _process_all(method: coinpool.PoolMethod, txs):
     return irs_reports, pool
 
 
-def process_all(method, txs):
+def process_all(method: coinpool.PoolMethod, txs: Sequence[Transaction]):
+    """
+    Given a method and a bunch of transactions, return a list with the CostBasisReports calculated.
+    """
+    assert method in coinpool.PoolMethod
     reports, pool = _process_all(method, txs)
     return reports
 
@@ -253,10 +257,10 @@ class BasisProcessor:
     """
 
     def __init__(self, method, txs):
-        assert method in coinpool.PoolMethod.FIFO, "LIFO"
+        assert method in coinpool.PoolMethod
         self.method = method
         self.txs = txs
-        self._reports = None
+        self._reports = []
 
     def process(self):
         reports, pool = _process_all(self.method, self.txs)

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -1,7 +1,5 @@
 """
 Calculating the cost basis.
-
-TODO: Add other accounting methods than FIFO, most notably LIFO.
 """
 import copy
 import csv

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -10,7 +10,7 @@ import typing
 from decimal import Decimal
 from typing import Sequence
 
-from yabc import formats
+from yabc import formats, coinpool
 from yabc import transaction
 from yabc import transaction_parser
 from yabc.costbasisreport import CostBasisReport
@@ -92,7 +92,7 @@ def split_report(coin_to_split: Transaction, amount, trans: Transaction):
     )
 
 
-def process_one(trans: transaction.Transaction, pool: typing.Sequence):
+def process_one(trans: transaction.Transaction, pool: coinpool.CoinPool):
     """
     Cost basis calculator for a single transaction. Return the 'diff'
     required to process this one tx.
@@ -113,36 +113,37 @@ def process_one(trans: transaction.Transaction, pool: typing.Sequence):
 
     :param trans: a buy or sell with fields filled
     :param pool: a sequence containing transaction.Transaction instances.
-    :param trans
 
-    :return json describing the transaction:
-    {'sell': [T1, T1], 'remove_from_pool': 1, 'add_to_pool': [T5]}
+    :return (basis_reports, diff): a tuple with any cost basis reports and a PoolDiff.
     """
+    diff = coinpool.PoolDiff()
     cost_basis_reports = []
     amount = Decimal(0)
     pool_index = -1
     if trans.is_input():
-        return {"basis_reports": [], "add": trans, "remove_index": -1}
+        diff.add(trans.asset_name, trans)
+        return ([], diff)
 
     while amount < trans.quantity:
         pool_index += 1
-        amount += pool[pool_index].quantity
+        amount += pool.get(trans.asset_name)[pool_index].quantity
     needs_split = (amount - trans.quantity) > 1e-5
 
     to_add = None
     if needs_split:
-        coin_to_split = pool[pool_index]
+        coin_to_split = pool.get(trans.asset_name)[pool_index]
         excess = amount - trans.quantity
         portion_of_split_coin_to_sell = coin_to_split.quantity - excess
         if trans.is_taxable_output():
             # Outgoing gifts would not trigger this.
             # TODO: Alert the user if the value of a gift exceeds $15,000, in which
-            # case gift taxes may be eligible...
+            #       case gift taxes may be eligible...
             cost_basis_reports.append(
                 split_report(coin_to_split, portion_of_split_coin_to_sell, trans)
             )
-        to_add = split_coin_to_add(coin_to_split, portion_of_split_coin_to_sell, trans)
-    needs_remove = pool_index
+        coin_to_add = split_coin_to_add(coin_to_split, portion_of_split_coin_to_sell, trans)
+        diff.add(coin_to_add.asset_name, coin_to_add)
+    diff.remove(trans.asset_name, pool_index)
     if not needs_split:
         pool_index += 1  # Ensures that we report the oldest transaction as a sale.
     if trans.is_taxable_output():
@@ -150,12 +151,7 @@ def process_one(trans: transaction.Transaction, pool: typing.Sequence):
         # The coins just magically remove themselves from the pool.
         # No entry in 8949 for them.
         cost_basis_reports.extend(_build_sale_reports(pool, pool_index, trans))
-
-    return {
-        "basis_reports": cost_basis_reports,
-        "add": to_add,
-        "remove_index": needs_remove,
-    }
+    return (cost_basis_reports, diff)
 
 
 def _build_sale_reports(pool, pool_index, trans: Transaction):
@@ -167,16 +163,16 @@ def _build_sale_reports(pool, pool_index, trans: Transaction):
         #
         # NOTE: the entire basis coin will be sold; but for each iteration
         # through we only use a portion of trans.
-        portion_of_sale = pool[i].quantity / trans.quantity
+        portion_of_sale = pool.get(trans.asset_name)[i].quantity / trans.quantity
         # The seller is allowed to inflate their cost basis for the BUY fees a bit.
         ir = CostBasisReport(
-            pool[i].user_id,
-            pool[i].usd_subtotal + pool[i].fees,
-            pool[i].quantity,
-            pool[i].date,
+            pool.get(trans.asset_name)[i].user_id,
+            pool.get(trans.asset_name)[i].usd_subtotal + pool.get(trans.asset_name)[i].fees,
+            pool.get(trans.asset_name)[i].quantity,
+            pool.get(trans.asset_name)[i].date,
             portion_of_sale * (trans.usd_subtotal - trans.fees),
             trans.date,
-            pool[i].asset_name,
+            pool.get(trans.asset_name)[i].asset_name,
             triggering_transaction=trans,
         )
         ans.append(ir)
@@ -189,7 +185,6 @@ def transactions_from_file(tx_file, expected_format):
 
     :param tx_file: the name of a csv file
     :param expected_format: a string, the name of the exchange. (gemini or coinbase)
-    :return:
     """
     hint = None
     if expected_format == "gemini":
@@ -222,53 +217,22 @@ def reports_to_csv(reports: Sequence[CostBasisReport]):
     return of
 
 
-def handle_add_lifo(pool, to_add: Transaction):
+def _process_all(method: coinpool.PoolMethod, txs):
     """
-    Simply put any new transaction, including splits, at the beginning.
-    """
-    pool.insert(0, to_add)
+    The meat and potatoes. Creates a transaction pool, and iteratively processes txs and saves the pool state and any
+    cost basis reports.
 
-
-def handle_add_fifo(pool, to_add: Transaction):
+    :param method: LIFO or FIFO
+    :param txs: a list of transactions (doesn't need to be sorted)
+    :return: reports to be sent to tax authorities, and a tx pool.
     """
-    FIFO is defined by putting the BUY transactions at the end.
-    For split coins, they need to be sold first.
-    """
-    if to_add.operation == Transaction.Operation.SPLIT:
-        pool.insert(0, to_add)
-    else:
-        assert to_add.operation in [
-            transaction.Operation.BUY,
-            transaction.Operation.MINING,
-            transaction.Operation.GIFT_RECEIVED,
-        ]
-        pool.append(to_add)
-
-
-def _process_all(method, txs):
-    """
-    The meat and potatoes
-    :param method:
-    :param txs:
-    :return:
-    """
-    pool = []
+    assert method in coinpool.PoolMethod
+    pool = coinpool.CoinPool(method)
     to_process = sorted(txs, key=lambda tx: tx.date)
     irs_reports = []
     for tx in to_process:
-        ops = process_one(tx, pool)
-        reports = ops["basis_reports"]
-        to_add = ops["add"]
-        remove_index = ops["remove_index"]
-        if remove_index > -1:
-            pool = pool[remove_index + 1 :]
-        if to_add is not None:
-            if method == "FIFO":
-                handle_add_fifo(pool, to_add)
-            elif method == "LIFO":
-                handle_add_lifo(pool, to_add)
-            else:
-                assert False
+        reports, diff = process_one(tx, pool)
+        pool.apply(diff)
         irs_reports.extend(reports)
     return irs_reports, pool
 
@@ -286,7 +250,7 @@ class BasisProcessor:
     """
 
     def __init__(self, method, txs):
-        assert method in "FIFO", "LIFO"
+        assert method in coinpool.PoolMethod.FIFO, "LIFO"
         self.method = method
         self.txs = txs
         self._reports = None

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -260,7 +260,7 @@ class BasisProcessor:
         self.txs = txs
         self._reports = []
 
-    def process(self):
+    def process(self) -> Sequence[CostBasisReport]:
         reports, pool = _process_all(self.method, self.txs)
         self._reports = reports
         self.pool = pool

--- a/src/yabc/coinpool.py
+++ b/src/yabc/coinpool.py
@@ -1,0 +1,106 @@
+#  Copyright (c) 2019. Seattle Blockchain Solutions. All rights reserved.
+#  Licensed under the MIT License. See LICENSE in the project root for license information.
+import enum
+from collections import defaultdict
+
+from yabc import transaction
+
+
+@enum.unique
+class PoolMethod(enum.Enum):
+    LIFO = 1
+    FIFO = 2
+
+class PoolDiff:
+    """
+    Operations to be applied to a CoinPool.
+
+    Supports add and remove.
+    """
+
+    def __init__(self):
+        self.to_add = []
+        self.to_remove= []
+
+    def add(self, symbol, coin: transaction.Transaction):
+        if not coin.asset_name == symbol:
+            raise RuntimeError("Cannot add to pool {}".format(symbol))
+        self.to_add.append(coin)
+
+    def remove(self, symbol, index):
+        assert isinstance(index, int)
+        assert isinstance(symbol, str)
+        self.to_remove.append((symbol, index))
+
+
+
+def _handle_add_lifo(pool, to_add: transaction.Transaction):
+    """
+    Simply put any new transaction, including splits, at the beginning.
+    """
+    pool.insert(0, to_add)
+
+
+def _handle_add_fifo(pool, to_add: transaction.Transaction):
+    """
+    FIFO is defined by putting the BUY transactions at the end.
+    For split coins, they need to be sold first.
+    """
+    if to_add.operation == transaction.Operation.SPLIT:
+        pool.insert(0, to_add)
+    else:
+        assert to_add.operation in [
+            transaction.Operation.BUY,
+            transaction.Operation.MINING,
+            transaction.Operation.GIFT_RECEIVED,
+        ]
+        pool.append(to_add)
+
+class CoinPool:
+    """
+    Consider trading BTC, getting ETH, and paying the fee in ETH.
+
+    - need to add ETH to the pool, less fees
+    - need to remove BTC from the pool
+        - potentially need to split a BTC coin
+        - if so, need to add BTC to the pool
+
+    Internal representation note: by convention, the coins at the START of the list will be sold first. This is for LIFO and FIFO.
+
+    """
+
+    def __init__(self, method: PoolMethod):
+        assert method in PoolMethod
+        self._coins = defaultdict(list)
+        self.method = method
+
+    def get(self, coin_name):
+        """
+        Read-only access to the pool of transactions for a given symbol.
+
+        Note that it's read-only by convention, and clients who modify the returned value are in for trouble.
+        TODO: Consider returning a copy here (?)
+
+        :return: A sequence of Transaction
+        """
+        return self._coins[coin_name]
+
+    def apply(self, diff: PoolDiff):
+        """
+        Pop from the front of a list of txs, or add in the correct spot based on method.
+
+        This mutates the object and isn't easy to undo.
+
+        :param diff:  a dictionary with keys remove_index, add,
+        """
+        for item in diff.to_add:
+            coin_list = self._coins[item.asset_name]
+            if self.method == PoolMethod.LIFO:
+                _handle_add_lifo(coin_list, item)
+            elif self.method == PoolMethod.FIFO:
+                _handle_add_fifo(coin_list, item)
+        for symbol, index in diff.to_remove:
+            self._coins[symbol] = self._coins[symbol][index + 1:]
+
+
+

--- a/src/yabc/coinpool.py
+++ b/src/yabc/coinpool.py
@@ -11,6 +11,7 @@ class PoolMethod(enum.Enum):
     LIFO = 1
     FIFO = 2
 
+
 class PoolDiff:
     """
     Operations to be applied to a CoinPool.
@@ -20,7 +21,7 @@ class PoolDiff:
 
     def __init__(self):
         self.to_add = []
-        self.to_remove= []
+        self.to_remove = []
 
     def add(self, symbol, coin: transaction.Transaction):
         if not coin.asset_name == symbol:
@@ -31,7 +32,6 @@ class PoolDiff:
         assert isinstance(index, int)
         assert isinstance(symbol, str)
         self.to_remove.append((symbol, index))
-
 
 
 def _handle_add_lifo(pool, to_add: transaction.Transaction):
@@ -55,6 +55,7 @@ def _handle_add_fifo(pool, to_add: transaction.Transaction):
             transaction.Operation.GIFT_RECEIVED,
         ]
         pool.append(to_add)
+
 
 class CoinPool:
     """
@@ -87,11 +88,10 @@ class CoinPool:
 
     def apply(self, diff: PoolDiff):
         """
+
         Pop from the front of a list of txs, or add in the correct spot based on method.
 
         This mutates the object and isn't easy to undo.
-
-        :param diff:  a dictionary with keys remove_index, add,
         """
         for item in diff.to_add:
             coin_list = self._coins[item.asset_name]
@@ -100,7 +100,4 @@ class CoinPool:
             elif self.method == PoolMethod.FIFO:
                 _handle_add_fifo(coin_list, item)
         for symbol, index in diff.to_remove:
-            self._coins[symbol] = self._coins[symbol][index + 1:]
-
-
-
+            self._coins[symbol] = self._coins[symbol][index + 1 :]

--- a/src/yabc/server/sql_backend.py
+++ b/src/yabc/server/sql_backend.py
@@ -15,8 +15,9 @@ from flask import make_response
 from flask.cli import with_appcontext
 from sqlalchemy.orm import sessionmaker
 
-from yabc import Base, coinpool
+from yabc import Base
 from yabc import basis
+from yabc import coinpool
 from yabc import costbasisreport
 from yabc import taxdoc
 from yabc import transaction

--- a/src/yabc/server/sql_backend.py
+++ b/src/yabc/server/sql_backend.py
@@ -15,7 +15,7 @@ from flask import make_response
 from flask.cli import with_appcontext
 from sqlalchemy.orm import sessionmaker
 
-from yabc import Base
+from yabc import Base, coinpool
 from yabc import basis
 from yabc import costbasisreport
 from yabc import taxdoc
@@ -312,7 +312,7 @@ class SqlBackend:
         all_txs = list(
             self.session.query(transaction.Transaction).filter_by(user_id=userid)
         )
-        basis_reports = basis.process_all("FIFO", all_txs)
+        basis_reports = basis.process_all(coinpool.PoolMethod.FIFO, all_txs)
         for i in basis_reports:
             self.session.add(i)
         self.session.commit()

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -58,6 +58,10 @@ class Market(enum.Enum):
 
 @enum.unique
 class Symbol(enum.Enum):
+    """
+    These aren't in wide use yet.
+    TODO: Migrate to use these instead of strings.
+    """
     BTC = 1
     ETH = 2
     BCH = 3
@@ -97,7 +101,7 @@ class Transaction(yabc.Base):
     quantity = sqlalchemy.Column(PreciseDecimalString)  # Deprecated
     date = sqlalchemy.Column(sqlalchemy.DateTime)
     fees = sqlalchemy.Column(PreciseDecimalString)
-    fee_symbol = sqlalchemy.Column(sqlalchemy.String)
+    fee_symbol = sqlalchemy.Column(sqlalchemy.String) # new in schema 8
     operation = sqlalchemy.Column(TransactionOperationString)
 
     quantity_traded = sqlalchemy.Column(PreciseDecimalString)  # column added

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -48,6 +48,7 @@ class Market(enum.Enum):
     """
     Note that we don't use auto() because it's not in python3.5
     """
+
     BTCUSD = 1
     ETHUSD = 2
     BCHUSD = 3
@@ -62,6 +63,7 @@ class Symbol(enum.Enum):
     These aren't in wide use yet.
     TODO: Migrate to use these instead of strings.
     """
+
     BTC = 1
     ETH = 2
     BCH = 3
@@ -101,7 +103,7 @@ class Transaction(yabc.Base):
     quantity = sqlalchemy.Column(PreciseDecimalString)  # Deprecated
     date = sqlalchemy.Column(sqlalchemy.DateTime)
     fees = sqlalchemy.Column(PreciseDecimalString)
-    fee_symbol = sqlalchemy.Column(sqlalchemy.String) # new in schema 8
+    fee_symbol = sqlalchemy.Column(sqlalchemy.String)  # new in schema 8
     operation = sqlalchemy.Column(TransactionOperationString)
 
     quantity_traded = sqlalchemy.Column(PreciseDecimalString)  # column added

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -181,12 +181,12 @@ class Transaction(yabc.Base):
 
 
 def make_transaction(
-    kind: Transaction.Operation=Transaction.Operation.BUY,
+    kind: Transaction.Operation = Transaction.Operation.BUY,
     quantity=1,
     fees=0,
     subtotal=10000,
     date=datetime.datetime(2015, 2, 5, 6, 27, 56, 373000),
-    asset_name="BTC"
+    asset_name="BTC",
 ):
     """
     Convenience method for creating valid transaction objects; used in tests only.

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -181,15 +181,23 @@ class Transaction(yabc.Base):
 
 
 def make_transaction(
-    kind: Transaction.Operation,
-    quantity,
-    fees,
-    subtotal,
+    kind: Transaction.Operation=Transaction.Operation.BUY,
+    quantity=1,
+    fees=0,
+    subtotal=10000,
     date=datetime.datetime(2015, 2, 5, 6, 27, 56, 373000),
+    asset_name="BTC"
 ):
+    """
+    Convenience method for creating valid transaction objects; used in tests only.
+
+    Without any parameters passed, creates a 1 BTC buy for 10,000 USD
+
+    TODO: Remove from here and add to tests if not used in the codebase.
+    """
     return Transaction(
         operation=kind,
-        asset_name="BTC",
+        asset_name=asset_name,
         date=date,
         fees=fees,
         quantity=quantity,

--- a/tests/fifo_test.py
+++ b/tests/fifo_test.py
@@ -45,7 +45,9 @@ class FifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all(coinpool.PoolMethod.FIFO, [purchase_with_fees, sale1, sale2])
+        reports = process_all(
+            coinpool.PoolMethod.FIFO, [purchase_with_fees, sale1, sale2]
+        )
         self.assertEqual(len(reports), 2)
         for i in reports:
             print(i)

--- a/tests/fifo_test.py
+++ b/tests/fifo_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from yabc import coinpool
 from yabc.basis import process_all
 from yabc.transaction import *
 
@@ -17,7 +18,7 @@ class FifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1000, date=self.start + self.one_day * 2
         )
-        reports = process_all("FIFO", [self.purchase, sale1, sale2])
+        reports = process_all(coinpool.PoolMethod.FIFO, [self.purchase, sale1, sale2])
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -29,7 +30,7 @@ class FifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 10, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all("FIFO", [self.purchase, sale1, sale2])
+        reports = process_all(coinpool.PoolMethod.FIFO, [self.purchase, sale1, sale2])
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -44,7 +45,7 @@ class FifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all("FIFO", [purchase_with_fees, sale1, sale2])
+        reports = process_all(coinpool.PoolMethod.FIFO, [purchase_with_fees, sale1, sale2])
         self.assertEqual(len(reports), 2)
         for i in reports:
             print(i)

--- a/tests/formats/csv_adhoc_test.py
+++ b/tests/formats/csv_adhoc_test.py
@@ -5,7 +5,8 @@ import datetime
 import unittest
 from decimal import Decimal
 
-from yabc import transaction, coinpool
+from yabc import coinpool
+from yabc import transaction
 from yabc.basis import process_all
 from yabc.formats import adhoc
 from yabc.transaction import Operation

--- a/tests/formats/csv_adhoc_test.py
+++ b/tests/formats/csv_adhoc_test.py
@@ -5,7 +5,7 @@ import datetime
 import unittest
 from decimal import Decimal
 
-from yabc import transaction
+from yabc import transaction, coinpool
 from yabc.basis import process_all
 from yabc.formats import adhoc
 from yabc.transaction import Operation
@@ -57,7 +57,7 @@ class CsvAdhocTest(unittest.TestCase):
         sale = make_transaction(
             Operation.SELL, 1, 0, 1001, date=self.start + self.one_day * 2
         )
-        reports = process_all("FIFO", [purchase, gift_given, sale])
+        reports = process_all(coinpool.PoolMethod.FIFO, [purchase, gift_given, sale])
         print(reports)
         self.assertEqual(len(reports), 1)
         sale_report = reports[0]
@@ -68,5 +68,5 @@ class CsvAdhocTest(unittest.TestCase):
         sold = make_transaction(
             Operation.SELL, 1, 0, 2000, date=self.start + self.one_day
         )
-        reports = process_all("FIFO", [sold, mined])
+        reports = process_all(coinpool.PoolMethod.FIFO, [sold, mined])
         self.assertEqual(reports[0].get_gain_or_loss(), 1000)

--- a/tests/lifo_test.py
+++ b/tests/lifo_test.py
@@ -45,7 +45,9 @@ class LifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all(coinpool.PoolMethod.LIFO, [purchase_with_fees, sale1, sale2])
+        reports = process_all(
+            coinpool.PoolMethod.LIFO, [purchase_with_fees, sale1, sale2]
+        )
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)

--- a/tests/lifo_test.py
+++ b/tests/lifo_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from yabc import coinpool
 from yabc.basis import process_all
 from yabc.transaction import *
 
@@ -17,7 +18,7 @@ class LifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1000, date=self.start + self.one_day * 2
         )
-        reports = process_all("LIFO", [self.purchase, sale1, sale2])
+        reports = process_all(coinpool.PoolMethod.LIFO, [self.purchase, sale1, sale2])
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -29,7 +30,7 @@ class LifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 10, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all("LIFO", [self.purchase, sale1, sale2])
+        reports = process_all(coinpool.PoolMethod.LIFO, [self.purchase, sale1, sale2])
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -44,7 +45,7 @@ class LifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all("LIFO", [purchase_with_fees, sale1, sale2])
+        reports = process_all(coinpool.PoolMethod.LIFO, [purchase_with_fees, sale1, sale2])
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -57,7 +58,7 @@ class LifoTest(unittest.TestCase):
         sale = make_transaction(
             Operation.SELL, 1, 0, 1200, date=self.start + 2 * self.one_day
         )
-        reports = process_all("LIFO", [purchase1, purchase2, sale])
+        reports = process_all(coinpool.PoolMethod.LIFO, [purchase1, purchase2, sale])
         self.assertEqual(len(reports), 1)
         r = reports[0]
         self.assertEqual(r.gain_or_loss, 1000)
@@ -70,7 +71,7 @@ class LifoTest(unittest.TestCase):
         sale = make_transaction(
             Operation.SELL, 1, 0, 1100, date=self.start + 2 * self.one_day
         )
-        reports = process_all("LIFO", [purchase1, sale])
+        reports = process_all(coinpool.PoolMethod.LIFO, [purchase1, sale])
         self.assertEqual(len(reports), 1)
         r = reports[0]
         self.assertEqual(r.gain_or_loss, 1000)

--- a/tests/multi_asset_test.py
+++ b/tests/multi_asset_test.py
@@ -1,0 +1,49 @@
+#  Copyright (c) 2019. Seattle Blockchain Solutions. All rights reserved.
+#  Licensed under the MIT License. See LICENSE in the project root for license information.
+
+import datetime
+import unittest
+
+from yabc import basis
+from yabc import coinpool
+from yabc.transaction import Operation
+from yabc.transaction import make_transaction
+
+TEN_K = 10000
+
+
+class MultiAssetTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.start = datetime.datetime.now()
+        self.one_day = datetime.timedelta(1)
+        self.purchase_bch = make_transaction(
+            Operation.BUY, 1, 0, 100, date=self.start - 2 * self.one_day
+        )
+        self.purchase_bch.asset_name = "BCH"
+        self.purchase_btc = make_transaction(
+            Operation.BUY, 1, 0, TEN_K, date=self.start - self.one_day
+        )
+
+    def test_sell_matches_symbol(self):
+        """
+        Sort of an integration test (because it tests several classes underneath the process_all api)
+
+        Make sure that when we sell BTC, we match with a previous BTC buy (and not BCH or something else)
+        :return:
+        """
+        sell_btc_no_profit = make_transaction(
+            Operation.SELL, 1, 0, TEN_K, date=self.start + self.one_day
+        )
+        # Note that they don't need to be in order.
+        processor = basis.BasisProcessor(
+            coinpool.PoolMethod.FIFO,
+            [self.purchase_bch, self.purchase_btc, sell_btc_no_profit],
+        )
+        reports = processor.process()
+        self.assertEqual(len(reports), 1)
+        report = reports[0]
+        self.assertEqual(report.asset_name, "BTC")
+        self.assertEqual(report.get_gain_or_loss(), 0)
+        self.assertEqual(report.proceeds, TEN_K)
+        self.assertEqual(processor.pool.get("BTC"), [])
+        self.assertEqual(len(processor.pool.get("BCH")), 1)

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -1,0 +1,39 @@
+#  Copyright (c) 2019. Seattle Blockchain Solutions. All rights reserved.
+#  Licensed under the MIT License. See LICENSE in the project root for license information.
+import datetime
+import unittest
+
+from yabc import coinpool
+from yabc import transaction
+
+
+class PoolRemoveSymbolMatches(unittest.TestCase):
+    def setUp(self) -> None:
+        pool = coinpool.CoinPool(coinpool.PoolMethod.FIFO)
+        diff = coinpool.PoolDiff()
+        yesterday = datetime.datetime.now() - datetime.timedelta(1)
+        diff.add(
+            "BCH",
+            transaction.Transaction(
+                transaction.Operation.BUY,
+                asset_name="BCH",
+                date=yesterday,
+                quantity=1,
+                usd_subtotal=100,
+            ),
+        )
+        diff.add(
+            "BTC",
+            transaction.Transaction(
+                transaction.Operation.BUY, date=yesterday, quantity=1, usd_subtotal=1000
+            ),
+        )
+        pool.apply(diff)
+        self.pool = pool
+
+    def test_multi_pool_remove_symbol_matches(self):
+        diff = coinpool.PoolDiff()
+        diff.remove("BCH", 0)
+        self.pool.apply(diff)
+        self.assertEqual(self.pool.get("BCH"), [])
+        self.assertEqual(len(self.pool.get("BTC")), 1)

--- a/tests/run_basis_test.py
+++ b/tests/run_basis_test.py
@@ -1,6 +1,7 @@
 import unittest
 
-from yabc import basis, coinpool
+from yabc import basis
+from yabc import coinpool
 from yabc.formats import coinbase
 
 

--- a/tests/run_basis_test.py
+++ b/tests/run_basis_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from yabc import basis
+from yabc import basis, coinpool
 from yabc.formats import coinbase
 
 
@@ -9,6 +9,6 @@ class RunBasisTest(unittest.TestCase):
         with open("testdata/multi_asset_coinbase.csv") as f:
             stuff = coinbase.from_coinbase(f)
             txs = [coinbase.FromCoinbaseJSON(i) for i in stuff]
-            reports = basis.process_all("FIFO", txs)
+            reports = basis.process_all(coinpool.PoolMethod.LIFO, txs)
             self.assertEqual(len(reports), 2)
             self.assertSetEqual(set([i.asset_name for i in reports]), {"BCH", "BTC"})

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -6,8 +6,9 @@ from decimal import Decimal
 import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 
-from yabc import Base, coinpool
+from yabc import Base
 from yabc import basis
+from yabc import coinpool
 from yabc import transaction
 from yabc import user  # noqa
 from yabc.formats import coinbase


### PR DESCRIPTION
Add a class for pools, instead of just using a list.

Also make sure we track each coin's list of txs separately.

# Notes
This is a partial step backwards in terms of migrating CBR to the `quantity_[received/traded]` syntax for the transactions table. This is because we're adding more usages of `asset_name` than there were previously.

However, it's important to fix the bug where a BCH sell could use the BTC basis (which is nonsensical)
 
# Test plan
- Run CBR and upload documents via web interface
  - added multi_asset_coinbase and checked the 2008 generated PDF. basis for BCH is correct.
- unit tests
- integration tests with make