### PR TITLE
populate new fields from old txs - coin/coin pt2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     author="Seattle Blockchain Solutions",
     maintainer="Robert Karl",
     maintainer_email="robertkarljr@gmail.com",
-    install_requires=["flask==1.0.2", "sqlalchemy", "delorean==1.0.0"],
+    install_requires=["flask==1.1.1", "sqlalchemy==1.3.3", "delorean==1.0.0"],
     test_suite="tests",
     url="https://github.com/robertkarl/yabc",
     description="A tax estimator for cryptocurrencies.",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import setuptools
 
 setuptools.setup(
-    version="0.1.9",
+    version="0.1.10",
     name="yabc",
     python_requires=">=3.5,<3.8",
     author="Seattle Blockchain Solutions",

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -154,6 +154,8 @@ class Transaction(yabc.Base):
         self.symbol_received = symbol_received
         self.symbol_traded = symbol_traded
 
+        self.init_on_load()
+
     def needs_migrate_away_from_asset_name(self):
         return self.symbol_received == '' and self.symbol_traded == ''
 

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 from decimal import Decimal
 
-import sqlalchemy
+import sqlalchemy.orm
 from sqlalchemy.types import TypeDecorator
 
 import yabc
@@ -92,10 +92,11 @@ class Transaction(yabc.Base):
         SELL = "Sell"
         GIFT_RECEIVED = "GiftReceived"
         GIFT_SENT = "GiftSent"
-        SPLIT = "Split"
         MINING = "Mining"
         SPENDING = "Spending"
+        # These aren't stored in the BD, put typically only used in basis calculations as temporary values.
         TRADE_INPUT = "TradeInput"
+        SPLIT = "Split"
 
     __tablename__ = "transaction"
     id = sqlalchemy.Column(sqlalchemy.Integer, primary_key=True)
@@ -124,7 +125,7 @@ class Transaction(yabc.Base):
         fees=0,
         quantity=0,
         source=None,
-        usd_subtotal=0,  # depreacted
+        usd_subtotal=0,  # deprecated
         user_id="",
         symbol_traded="",
         symbol_received="",
@@ -153,8 +154,36 @@ class Transaction(yabc.Base):
         self.symbol_received = symbol_received
         self.symbol_traded = symbol_traded
 
+    def needs_migrate_away_from_asset_name(self):
+        return self.symbol_received == '' and self.symbol_traded == ''
+
+    @sqlalchemy.orm.reconstructor
+    def init_on_load(self):
+        """
+        Restore fields from self.asset_name and self.quantity to the more general columns.
+        """
+        if not self.needs_migrate_away_from_asset_name():
+            # Do not modify the object further if we've already restored fields.
+            return
+
+        self.fee_symbol = 'USD' # Not possible to have others, until binance or other coin/coin markets are added.
+        if self.is_input():
+            self.symbol_received = self.asset_name
+            self.quantity_received = self.quantity
+            self.symbol_traded = 'USD'
+            self.quantity_traded = self.usd_subtotal
+        else:
+            # Check the assumption that there are no SPLITs in the DB.
+            assert self.operation in {Operation.SPENDING, Operation.GIFT_SENT, Operation.SELL}
+            # We assume that these are SELLs in the sense that we are trading away BTC and receiving cash.
+            self.symbol_traded = self.asset_name
+            self.quantity_traded = self.quantity
+            self.symbol_received = "USD"
+            self.quantity_received = self.usd_subtotal
+
     def is_input(self):
         """
+        TODO: coin/coin trades make this more complicated, as SELLs can also be inputs.
         :return: True if this transaction is an input (like mining, a gift received, or a purchase)
         """
         return self.operation in {

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -157,7 +157,7 @@ class Transaction(yabc.Base):
         self.init_on_load()
 
     def needs_migrate_away_from_asset_name(self):
-        return self.symbol_received == '' and self.symbol_traded == ''
+        return self.symbol_received == "" and self.symbol_traded == ""
 
     @sqlalchemy.orm.reconstructor
     def init_on_load(self):
@@ -168,15 +168,21 @@ class Transaction(yabc.Base):
             # Do not modify the object further if we've already restored fields.
             return
 
-        self.fee_symbol = 'USD' # Not possible to have others, until binance or other coin/coin markets are added.
+        self.fee_symbol = (
+            "USD"
+        )  # Not possible to have others, until binance or other coin/coin markets are added.
         if self.is_input():
             self.symbol_received = self.asset_name
             self.quantity_received = self.quantity
-            self.symbol_traded = 'USD'
+            self.symbol_traded = "USD"
             self.quantity_traded = self.usd_subtotal
         else:
             # Check the assumption that there are no SPLITs in the DB.
-            assert self.operation in {Operation.SPENDING, Operation.GIFT_SENT, Operation.SELL}
+            assert self.operation in {
+                Operation.SPENDING,
+                Operation.GIFT_SENT,
+                Operation.SELL,
+            }
             # We assume that these are SELLs in the sense that we are trading away BTC and receiving cash.
             self.symbol_traded = self.asset_name
             self.quantity_traded = self.quantity


### PR DESCRIPTION
# Overall migration plan
We need to check that each type of transaction (mining / sell /etc) can have their values restored when loaded from the ORM.

- [x] load existing values into memory, check correctness
- [x] start populating the new columns for imports
- [ ] start using new columns for calculations (not accomplished here)

# Test plan
run CBR against a DB and examine gifts, spending, sells, and buys.

Looks correct