### PR TITLE
Bubble up flags from basis processor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 script:
 - PYTHONPATH=tests python setup.py test
 - make nuke_db_and_run& sleep 5; make test_all
+- python -m yabc testdata/gemini/synthetic_gemini_csv.csv ./testdata/synthetic_coinbase_csv.csv
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -10,28 +10,28 @@ reports that can be sent to tax authorities.
 yabc is the tax calculator behind [https://costbasis.report/](https://costbasis.report/).
 
 ```
-$ pip install yabc
-$ python -m yabc ./testdata/synthetic_gemini_csv.csv ./testdata/synthetic_coinbase_csv.csv 
+python -m yabc testdata/gemini/synthetic_gemini_csv.csv ./testdata/synthetic_coinbase_csv.csv 
 13 transactions to be reported
 
-<Sold 0.76 BTC for 236 total profiting -155. Adjustment 0>
-<Sold 1 BTC for 311 total profiting 29. Adjustment 0>
-<Sold 2 BTC for 622 total profiting 546. Adjustment 0>
-<Sold 2.5 BTC for 777 total profiting 666. Adjustment 0>
-<Sold 0.04290503 BTC for 594 total profiting 572. Adjustment 0>
-<Sold 0.35608537 BTC for 4929 total profiting 4746. Adjustment 0>
-<Sold 0.00100960 BTC for 14 total profiting 13. Adjustment 0>
-<Sold 0.50000000 BTC for 7032 total profiting 6775. Adjustment 0>
-<Sold 0.03500000 BTC for 496 total profiting 478. Adjustment 0>
-<Sold 0.03518002 BTC for 498 total profiting 480. Adjustment 0>
-<Sold 0.03447186 BTC for 488 total profiting 470. Adjustment 0>
-<Sold 0.01057786 BTC for 150 total profiting 145. Adjustment 0>
-<Sold 0.03500000 BTC for 496 total profiting 478. Adjustment 0>
+<Sold 0.76 BTC on 2008-04-21 01:12:00 for $236. Exchange: coinbase. Profit:$-155.>
+<Sold 1 BTC on 2008-04-21 01:12:00 for $311. Exchange: coinbase. Profit:$29.>
+<Sold 2 BTC on 2008-04-21 01:12:00 for $622. Exchange: coinbase. Profit:$546.>
+<Sold 2.5 BTC on 2008-04-21 01:12:00 for $777. Exchange: coinbase. Profit:$666.>
+<Sold 0.04290503 BTC on 2008-08-13 06:27:56.145000 for $594. Exchange: gemini. Profit:$572.>
+<Sold 0.35608537 BTC on 2008-08-14 06:27:56.146000 for $4929. Exchange: gemini. Profit:$4746.>
+<Sold 0.0010096 BTC on 2008-08-15 06:27:56.147000 for $14. Exchange: gemini. Profit:$13.>
+<Sold 0.5 BTC on 2008-08-18 06:27:56.150000 for $7032. Exchange: gemini. Profit:$6775. Long term.>
+<Sold 0.035 BTC on 2008-08-20 06:27:56.152000 for $496. Exchange: gemini. Profit:$478. Long term.>
+<Sold 0.03518002 BTC on 2008-08-21 06:27:56.153000 for $498. Exchange: gemini. Profit:$480. Long term.>
+<Sold 0.03447186 BTC on 2008-08-22 06:27:56.154000 for $488. Exchange: gemini. Profit:$470. Long term.>
+<Sold 0.01057786 BTC on 2008-08-23 06:27:56.155000 for $150. Exchange: gemini. Profit:$145. Long term.>
+<Sold 0.035 BTC on 2009-08-24 06:27:56.156000 for $496. Exchange: gemini. Profit:$478. Long term.>
 
 total gain or loss for above transactions: 15243
 
 total basis for above transactions: 1400
 total proceeds for above transactions: 16643
+Remaining coins after sales: <yabc.coinpool.CoinPool object at 0x7f831da9e208>
 ```
 
 An adhoc CSV format is supported for non-exchange transactions like mining and purchases.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 
 # yabc - a bitcoin tax calculator
 yabc translates cryptocurrency trades, mining, and spending data into a list of
-reports that can be sent to tax authorities.  
+reports that can be sent to tax authorities. It is most useful for
+cryptocurrency traders in the US.
 
-yabc is the tax calculator behind [https://costbasis.report/](https://costbasis.report/).
+yabc is the tax calculator behind [https://CostBasis.Report/](https://costbasis.report/).
 
 ```
 python -m yabc testdata/gemini/synthetic_gemini_csv.csv ./testdata/synthetic_coinbase_csv.csv 
@@ -34,7 +35,7 @@ total proceeds for above transactions: 16643
 Remaining coins after sales: <yabc.coinpool.CoinPool object at 0x7f831da9e208>
 ```
 
-An adhoc CSV format is supported for non-exchange transactions like mining and purchases.
+An adhoc CSV format is supported for non-exchange transactions like mining, gifts, and purchases.
 
 yabc also includes a set of HTTP endpoints that allow for storing data more
 permanently in a database, sqlite by default. Postgres as a backend is also supported.
@@ -43,9 +44,9 @@ permanently in a database, sqlite by default. Postgres as a backend is also supp
 
 - [ ] TODO: Support coin/coin trades like BTC/ETH.
 - [ ] TODO: Enable importing from more exchanges (binance)
-- [ ] TODO: Add better historical price lookup support; it is now a stub that returns $17
+- [ ] TODO: Add better historical price lookup support; it is now a stub.
 
-# Installation, with virtualenv
+# Installation from source, with virtualenv
 ```
 git clone git@github.com:robertkarl/yabc.git
 cd yabc

--- a/src/yabc/__main__.py
+++ b/src/yabc/__main__.py
@@ -15,6 +15,7 @@ import sys
 
 import yabc.transaction_parser
 from yabc import basis
+from yabc import coinpool
 from yabc.costbasisreport import ReportBatch
 
 

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -53,7 +53,7 @@ def _split_coin_to_add(coin_to_split, amount, trans):
     return to_add
 
 
-def split_report(coin_to_split, amount, trans):
+def _split_report(coin_to_split, amount, trans):
     # type:  (transaction.Transaction, Decimal, transaction.Transaction) -> transaction.Transaction
     """
     The cost basis logic. Note that all fees on buy and sell sides are
@@ -128,9 +128,6 @@ def _process_one(trans, pool, ohlc_source=None):
         diff.add(trans.symbol_received, trans)
         return ([], diff, [])
     # At this point, trans is a sell
-
-    # TODO: Whenever we use quantity on a SELL transaction, we really mean
-    #       quantity_traded. Is this true?
     while amount < trans.quantity_traded:
         pool_index += 1
         curr_pool = pool.get(trans.symbol_traded)
@@ -153,7 +150,7 @@ def _process_one(trans, pool, ohlc_source=None):
             # TODO: Alert the user if the value of a gift exceeds $15,000, in which
             #       case gift taxes may be eligible...
             cost_basis_reports.append(
-                split_report(coin_to_split, portion_of_split_coin_to_sell, trans)
+                _split_report(coin_to_split, portion_of_split_coin_to_sell, trans)
             )
         coin_to_add = _split_coin_to_add(
             coin_to_split, portion_of_split_coin_to_sell, trans

--- a/src/yabc/coinpool.py
+++ b/src/yabc/coinpool.py
@@ -17,7 +17,6 @@ class PoolDiff:
     Operations to be applied to a CoinPool.
 
     Supports add and remove.
-
     """
 
     def __init__(self):
@@ -35,8 +34,6 @@ class PoolDiff:
         """
         The coins up to and including this index will be REMOVED from the pool.
         """
-        assert isinstance(index, int)
-        assert isinstance(symbol, str)
         self.to_remove.append((symbol, index))
 
 
@@ -72,11 +69,12 @@ class CoinPool:
         - potentially need to split a BTC coin
         - if so, need to add BTC to the pool
 
-    Internal representation note: by convention, the coins at the START of the list will be sold first. This is for LIFO and FIFO.
-
+    Internal representation note: by convention, the coins at the START of the
+    list will be sold first. This is for LIFO and FIFO.
     """
 
-    def __init__(self, method: PoolMethod):
+    def __init__(self, method):
+        # type: (PoolMethod) -> None
         assert method in PoolMethod
         self._coins = defaultdict(list)
         self.method = method
@@ -94,7 +92,6 @@ class CoinPool:
 
     def apply(self, diff: PoolDiff):
         """
-
         Pop from the front of a list of txs, or add in the correct spot based on method.
 
         This mutates the object and isn't easy to undo.
@@ -106,4 +103,4 @@ class CoinPool:
             elif self.method == PoolMethod.FIFO:
                 _handle_add_fifo(coin_list, item)
         for symbol, index in diff.to_remove:
-            self._coins[symbol] = self._coins[symbol][index + 1 :]
+            self._coins[symbol] = self._coins[symbol][index + 1:]

--- a/src/yabc/coinpool.py
+++ b/src/yabc/coinpool.py
@@ -17,6 +17,7 @@ class PoolDiff:
     Operations to be applied to a CoinPool.
 
     Supports add and remove.
+
     """
 
     def __init__(self):
@@ -31,6 +32,9 @@ class PoolDiff:
 
     def remove(self, symbol, index):
         # type: (str, int) -> None
+        """
+        The coins up to and including this index will be REMOVED from the pool.
+        """
         assert isinstance(index, int)
         assert isinstance(symbol, str)
         self.to_remove.append((symbol, index))

--- a/src/yabc/costbasisreport.py
+++ b/src/yabc/costbasisreport.py
@@ -12,6 +12,7 @@ from sqlalchemy import Integer
 from sqlalchemy import orm
 
 import yabc
+from yabc import transaction
 from yabc.transaction import PreciseDecimalString
 
 
@@ -79,6 +80,7 @@ class CostBasisReport(yabc.Base):
         adjustment=Decimal(0),
         triggering_transaction=None,
     ):
+        # type: (int, decimal.Decimal, decimal.Decimal, datetime.datetime, decimal.Decimal, datetime.datetime, str, decimal.Decimal, transaction.Transaction) -> None
         """
         Note that when pulling items from a SQL alchemy ORM query, this constructor isn't called.
         """

--- a/src/yabc/ohlcprovider.py
+++ b/src/yabc/ohlcprovider.py
@@ -26,8 +26,7 @@ class OhlcProvider:
     def __init__(self):
         pass
 
-    @staticmethod
-    def get(symbol, dt):
+    def get(self, symbol, dt):
         # type: (str, datetime.datetime) -> OhlcData
         """
         Return the fiat OHLC prices.

--- a/src/yabc/server/sql_backend.py
+++ b/src/yabc/server/sql_backend.py
@@ -317,7 +317,9 @@ class SqlBackend:
         all_txs = list(
             self.session.query(transaction.Transaction).filter_by(user_id=userid)
         )
-        basis_reports = basis.process_all(coinpool.PoolMethod.FIFO, all_txs)
+        bp = basis.BasisProcessor(coinpool.PoolMethod.FIFO, all_txs)
+        basis_reports = bp.process()
+
         for i in basis_reports:
             self.session.add(i)
         self.session.commit()

--- a/tests/basis/__init__.py
+++ b/tests/basis/__init__.py
@@ -3,4 +3,7 @@
 
 """
 BasisProcessor integration tests
+
+Perhaps the most important tests we have, these check that various input transactions
+result in sensible BasisProcessor outputs.
 """

--- a/tests/basis/single_sale_test.py
+++ b/tests/basis/single_sale_test.py
@@ -1,0 +1,23 @@
+#  Copyright (c) 2019. Seattle Blockchain Solutions. All rights reserved.
+#  Licensed under the MIT License. See LICENSE in the project root for license information.
+import unittest
+
+from transaction_utils import make_sale
+from yabc import basis
+from yabc.coinpool import CoinPool, PoolMethod
+
+
+class SingleSaleTest(unittest.TestCase):
+    def setUp(self) -> None:
+        pass
+    def test_single_sale(self):
+        txs = [make_sale()]
+        bp = basis.BasisProcessor(PoolMethod.LIFO, txs)
+        reports = bp.process()
+        self.assertEqual(len(reports), 1)
+        report = reports[0]
+        self.assertEqual(report.date_sold, txs[0].date)
+        self.assertEqual(report.date_purchased, txs[0].date)
+        self.assertEqual(report.basis, 0)
+        self.assertEqual(report.proceeds, txs[0].quantity_received)
+        self.assertEqual(len(bp.flags()), 1)

--- a/tests/basis/single_sale_test.py
+++ b/tests/basis/single_sale_test.py
@@ -8,9 +8,10 @@ from yabc.coinpool import PoolMethod
 
 
 class SingleSaleTest(unittest.TestCase):
-    def setUp(self) -> None:
-        pass
-
+    """
+    Check that just a sale (no previous buy for that tx) raises a flag and
+    generates a short term CostBasisReport.
+    """
     def test_single_sale(self):
         txs = [make_sale()]
         bp = basis.BasisProcessor(PoolMethod.LIFO, txs)

--- a/tests/basis/single_sale_test.py
+++ b/tests/basis/single_sale_test.py
@@ -4,12 +4,13 @@ import unittest
 
 from transaction_utils import make_sale
 from yabc import basis
-from yabc.coinpool import CoinPool, PoolMethod
+from yabc.coinpool import PoolMethod
 
 
 class SingleSaleTest(unittest.TestCase):
     def setUp(self) -> None:
         pass
+
     def test_single_sale(self):
         txs = [make_sale()]
         bp = basis.BasisProcessor(PoolMethod.LIFO, txs)

--- a/tests/fifo_test.py
+++ b/tests/fifo_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from transaction_utils import make_transaction
 from yabc import coinpool
-from yabc.basis import process_all
+from yabc.basis import BasisProcessor
 from yabc.transaction import *
 
 
@@ -19,7 +19,9 @@ class FifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1000, date=self.start + self.one_day * 2
         )
-        reports = process_all(coinpool.PoolMethod.FIFO, [self.purchase, sale1, sale2])
+        reports = BasisProcessor(
+            coinpool.PoolMethod.FIFO, [self.purchase, sale1, sale2]
+        ).process()
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -31,7 +33,9 @@ class FifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 10, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all(coinpool.PoolMethod.FIFO, [self.purchase, sale1, sale2])
+        reports = BasisProcessor(
+            coinpool.PoolMethod.FIFO, [self.purchase, sale1, sale2]
+        ).process()
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -46,9 +50,9 @@ class FifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all(
+        reports = BasisProcessor(
             coinpool.PoolMethod.FIFO, [purchase_with_fees, sale1, sale2]
-        )
+        ).process()
         self.assertEqual(len(reports), 2)
         for i in reports:
             print(i)

--- a/tests/formats/csv_adhoc_test.py
+++ b/tests/formats/csv_adhoc_test.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from transaction_utils import make_transaction
 from yabc import coinpool
 from yabc import transaction
-from yabc.basis import process_all
+from yabc.basis import BasisProcessor
 from yabc.formats import adhoc
 from yabc.transaction import Operation
 
@@ -63,7 +63,9 @@ class CsvAdhocTest(unittest.TestCase):
         sale = make_transaction(
             Operation.SELL, 1, 0, 1001, date=self.start + self.one_day * 2
         )
-        reports = process_all(coinpool.PoolMethod.FIFO, [purchase, gift_given, sale])
+        reports = BasisProcessor(
+            coinpool.PoolMethod.FIFO, [purchase, gift_given, sale]
+        ).process()
         print(reports)
         self.assertEqual(len(reports), 1)
         sale_report = reports[0]
@@ -81,5 +83,5 @@ class CsvAdhocTest(unittest.TestCase):
         sold = make_transaction(
             Operation.SELL, 1, 0, 2000, date=self.start + self.one_day
         )
-        reports = process_all(coinpool.PoolMethod.FIFO, [sold, mined])
+        reports = BasisProcessor(coinpool.PoolMethod.FIFO, [sold, mined]).process()
         self.assertEqual(reports[0].get_gain_or_loss(), 1000)

--- a/tests/lifo_test.py
+++ b/tests/lifo_test.py
@@ -4,7 +4,7 @@ import unittest
 from transaction_utils import make_buy
 from transaction_utils import make_transaction
 from yabc import coinpool
-from yabc.basis import process_all
+from yabc.basis import BasisProcessor
 from yabc.transaction import Operation
 
 
@@ -21,7 +21,10 @@ class LifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1000, date=self.start + self.one_day * 2
         )
-        reports = process_all(coinpool.PoolMethod.LIFO, [self.purchase, sale1, sale2])
+
+        reports = BasisProcessor(
+            coinpool.PoolMethod.LIFO, [self.purchase, sale1, sale2]
+        ).process()
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -33,7 +36,9 @@ class LifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 10, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all(coinpool.PoolMethod.LIFO, [self.purchase, sale1, sale2])
+        reports = BasisProcessor(
+            coinpool.PoolMethod.LIFO, [self.purchase, sale1, sale2]
+        ).process()
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -48,9 +53,9 @@ class LifoTest(unittest.TestCase):
         sale2 = make_transaction(
             Operation.SELL, 1, 0, 1010, date=self.start + self.one_day * 2
         )
-        reports = process_all(
+        reports = BasisProcessor(
             coinpool.PoolMethod.LIFO, [purchase_with_fees, sale1, sale2]
-        )
+        ).process()
         self.assertEqual(len(reports), 2)
         for i in reports:
             self.assertEqual(i.gain_or_loss, 0)
@@ -63,7 +68,9 @@ class LifoTest(unittest.TestCase):
         sale = make_transaction(
             Operation.SELL, 1, 0, 1200, date=self.start + 2 * self.one_day
         )
-        reports = process_all(coinpool.PoolMethod.LIFO, [purchase1, purchase2, sale])
+        reports = BasisProcessor(
+            coinpool.PoolMethod.LIFO, [purchase1, purchase2, sale]
+        ).process()
         self.assertEqual(len(reports), 1)
         r = reports[0]
         self.assertEqual(r.gain_or_loss, 1000)
@@ -73,7 +80,7 @@ class LifoTest(unittest.TestCase):
         sale = make_transaction(
             Operation.SELL, 1, 0, 1100, date=self.start + 2 * self.one_day
         )
-        reports = process_all(coinpool.PoolMethod.LIFO, [purchase1, sale])
+        reports = BasisProcessor(coinpool.PoolMethod.LIFO, [purchase1, sale]).process()
         self.assertEqual(len(reports), 1)
         r = reports[0]
         self.assertEqual(r.gain_or_loss, 1000)

--- a/tests/run_basis_test.py
+++ b/tests/run_basis_test.py
@@ -1,7 +1,7 @@
 import unittest
 
-from yabc import basis
 from yabc import coinpool
+from yabc.basis import BasisProcessor
 from yabc.formats import coinbase
 
 
@@ -10,6 +10,7 @@ class RunBasisTest(unittest.TestCase):
         with open("testdata/multi_asset_coinbase.csv") as f:
             stuff = coinbase.from_coinbase(f)
             txs = [coinbase.FromCoinbaseJSON(i) for i in stuff]
-            reports = basis.process_all(coinpool.PoolMethod.LIFO, txs)
+            processor = BasisProcessor(coinpool.PoolMethod.LIFO, txs)
+            reports = processor.process()
             self.assertEqual(len(reports), 2)
             self.assertSetEqual(set([i.asset_name for i in reports]), {"BCH", "BTC"})

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -50,7 +50,7 @@ class TransactionTest(unittest.TestCase):
         """
         buy = make_buy(1.0, fees=0, subtotal=100.0)
         sell = make_transaction(SELL, 1.0, 0, 100.0)
-        report = basis.split_report(buy, Decimal("0.5"), sell)
+        report = basis._split_report(buy, Decimal("0.5"), sell)
         self.assertEqual(report.gain_or_loss, 0)
 
     def test_split_report(self):
@@ -58,7 +58,7 @@ class TransactionTest(unittest.TestCase):
         """
         buy = make_transaction(BUY, 1.0, 10, 100.0)
         sell = make_transaction(SELL, 1.0, 10, 200.0)
-        report = basis.split_report(buy, Decimal("0.5"), sell)
+        report = basis._split_report(buy, Decimal("0.5"), sell)
         ans_gain_or_loss = 40.0
         self.assertEqual(report.gain_or_loss, ans_gain_or_loss)
 
@@ -69,7 +69,7 @@ class TransactionTest(unittest.TestCase):
         buy = make_transaction(BUY, purchase_quantity, 0, 100.0)
         sell = make_transaction(SELL, 2.0, 0, 100.0)
         with self.assertRaises(AssertionError):
-            basis.split_report(
+            basis._split_report(
                 buy, purchase_quantity, sell
             )  # Should not split the basis coin, quantity matches
 

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -42,7 +42,7 @@ class TransactionTest(unittest.TestCase):
         # Cost basis: (purchase price + fees) / quantity = 500
         # Proceeds: (.5 / (1010 - 10)) = 500
         # This transaction should result in $0 of capital gains.
-        reports, _ = basis.process_one(sale, pool)
+        reports, _ = basis._process_one(sale, pool)
         self.assertEqual(reports[0].gain_or_loss, 0)
 
     def test_split_report_no_gain(self):

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -42,7 +42,7 @@ class TransactionTest(unittest.TestCase):
         # Cost basis: (purchase price + fees) / quantity = 500
         # Proceeds: (.5 / (1010 - 10)) = 500
         # This transaction should result in $0 of capital gains.
-        reports, _ = basis._process_one(sale, pool)
+        reports, _, _ = basis._process_one(sale, pool)
         self.assertEqual(reports[0].gain_or_loss, 0)
 
     def test_split_report_no_gain(self):


### PR DESCRIPTION
- Add the ability to pass flags from `_process_one` to the end user of the BasisProcessor

# test plan
- add a tests that uses a file that contains only a single sell. The single sell has no basis information, so running the BasisProcessor should work. However, a flag should be raised and the CostBasisReport should be a short-term sale with a basis of $0.