### PR TITLE
Add coins back to the pool - coin/coin pt7

### DIFF
--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -327,7 +327,7 @@ class BasisProcessor:
         self._method = method
         self._txs = txs
         self._reports = []
-        self.pool = None
+        self._pool = None
         self._flags = None
 
     def flags(self):
@@ -337,7 +337,7 @@ class BasisProcessor:
 
     def get_pool(self):
         # type: () -> coinpool.CoinPool
-        return self.pool
+        return self._pool
 
     def process(self):
         # type: () -> Sequence[CostBasisReport]
@@ -350,6 +350,6 @@ class BasisProcessor:
         """
         reports, pool, flags = _process_all(self._method, self._txs, self.ohlc)
         self._reports = reports
-        self.pool = pool
+        self._pool = pool
         self._flags = flags
         return self._reports

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -110,7 +110,7 @@ def _process_one(trans, pool, ohlc_source=None):
     works for both LIFO and FIFO.
 
     - If transaction is a buy, just return the add-to-pool op.
-    - Otherwise, for a sale::
+    - Otherwise, for a sale:
         - Example: buy 0.25 @ $1 and 0.25 at $2. Then sell 0.5 at $3.
                    this is reported to IRS as 2 transactions:
                    One: Sell 0.25 with a basis of $1
@@ -173,7 +173,29 @@ def _process_one(trans, pool, ohlc_source=None):
                 pool, pool_index, trans, basis_information_absent, ohlc_source
             )
         )
+    if trans.is_coin_to_coin():
+        to_add = _get_coin_to_coin_input(trans)
+        diff.add(to_add.symbol_received, to_add)
+
     return (cost_basis_reports, diff, flags)
+
+
+def _get_coin_to_coin_input(trans):
+    # type: (transaction.Transaction) -> transaction.Transaction
+    """
+    For a coin/coin trade, we need to add an input back to the pool.
+    """
+    return transaction.Transaction(
+        transaction.Operation.TRADE_INPUT,
+        symbol_received=trans.symbol_received,
+        quantity_received=trans.quantity_received,
+        symbol_traded="USD",
+        quantity_traded=0,
+        fee_symbol="USD",
+        fees=0,
+        user_id=trans.user_id,
+        source=trans.source,
+    )
 
 
 def _build_sale_reports(pool, pool_index, trans, basis_information_absent, ohlc):
@@ -278,7 +300,7 @@ def _process_all(method, txs, ohlc_source=None):
     """
     assert method in coinpool.PoolMethod
     pool = coinpool.CoinPool(method)
-    to_process = sorted(txs, key=lambda tx: tx.date)
+    to_process = sorted(txs, key=lambda trans: trans.date)
     irs_reports = []
     flags = []
     for tx in to_process:

--- a/src/yabc/coinpool.py
+++ b/src/yabc/coinpool.py
@@ -26,7 +26,7 @@ class PoolDiff:
 
     def add(self, symbol, coin):
         # type: (str, transaction.Transaction) -> None
-        if not coin.asset_name == symbol:
+        if not coin.symbol_received == symbol:
             raise RuntimeError("Cannot add to pool {}".format(symbol))
         self.to_add.append(coin)
 
@@ -57,6 +57,7 @@ def _handle_add_fifo(pool, to_add: transaction.Transaction):
             transaction.Operation.BUY,
             transaction.Operation.MINING,
             transaction.Operation.GIFT_RECEIVED,
+            transaction.Operation.TRADE_INPUT,
         ]
         pool.append(to_add)
 

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -240,6 +240,7 @@ class Transaction(yabc.Base):
             Operation.GIFT_RECEIVED,
             Operation.SPLIT,
             Operation.BUY,
+            Operation.TRADE_INPUT,
         }:
             return True
         if self.Operation == Operation.SELL:

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -42,6 +42,7 @@ class TransactionOperationString(TypeDecorator):
             value = Transaction.Operation.NOOP
         return Transaction.Operation(value)
 
+
 @enum.unique
 class Market(enum.Enum):
     """
@@ -221,16 +222,29 @@ class Transaction(yabc.Base):
             self.quantity_received = self.usd_subtotal
 
     def is_simple_input(self):
-        """
-        TODO: coin/coin trades make this more complicated, as SELLs can also be inputs.
-        :return: True if this transaction is an input (like mining, a gift received, or a purchase)
-        """
         return self.operation in {
             Operation.MINING,
             Operation.GIFT_RECEIVED,
             Operation.SPLIT,
             Operation.BUY,
+            Operation.TRADE_INPUT,
         }
+
+    def trade_has_input(self):
+        """
+        TODO: coin/coin trades make this more complicated, as SELLs can also be inputs.
+        :return: True if this transaction is an input (like mining, a gift received, or a purchase)
+        """
+        if self.operation in {
+            Operation.MINING,
+            Operation.GIFT_RECEIVED,
+            Operation.SPLIT,
+            Operation.BUY,
+        }:
+            return True
+        if self.Operation == Operation.SELL:
+            return self.is_coin_to_coin()
+        return False
 
     def is_taxable_output(self):
         return self.operation in {Operation.SPENDING, Operation.SELL}

--- a/tests/basis/test_coin_to_coin.py
+++ b/tests/basis/test_coin_to_coin.py
@@ -51,7 +51,6 @@ class CoinToCoinTest(unittest.TestCase):
         fees = decimal.Decimal(".001") * daily_val
         computed_value = value_of_sell - fees
         self.assertEqual(report.proceeds, computed_value.quantize(1))
-        pool = self.bp.pool  # type: coinpool.CoinPool
+        pool = self.bp.get_pool()
         self.assertEqual(len(pool._coins.keys()), 2)
-        # TODO: Add the received BTC to pool and enable this test.
         self.assertEqual(len(pool.get("BTC")), 1)

--- a/tests/basis/test_coin_to_coin.py
+++ b/tests/basis/test_coin_to_coin.py
@@ -52,6 +52,6 @@ class CoinToCoinTest(unittest.TestCase):
         computed_value = value_of_sell - fees
         self.assertEqual(report.proceeds, computed_value.quantize(1))
         pool = self.bp.pool  # type: coinpool.CoinPool
-        self.assertEqual(len(pool._coins.keys()), 1)
+        self.assertEqual(len(pool._coins.keys()), 2)
         # TODO: Add the received BTC to pool and enable this test.
-        # self.assertEqual(len(pool.get("BTC")), 1)
+        self.assertEqual(len(pool.get("BTC")), 1)

--- a/tests/test_multi_asset.py
+++ b/tests/test_multi_asset.py
@@ -48,5 +48,5 @@ class MultiAssetTest(unittest.TestCase):
         self.assertEqual(report.asset_name, "BTC")
         self.assertEqual(report.get_gain_or_loss(), 0)
         self.assertEqual(report.proceeds, TEN_K)
-        self.assertEqual(processor.pool.get("BTC"), [])
-        self.assertEqual(len(processor.pool.get("BCH")), 1)
+        self.assertEqual(processor._pool.get("BTC"), [])
+        self.assertEqual(len(processor._pool.get("BCH")), 1)


### PR DESCRIPTION
For supporting coin/coin trades, when we trade ETH and receive BTC we need to add BTC to the LIFO or FIFO pool.

This PR adds that ability.

Remaining things needed for fully supporting coin/coin trades:
- price lookup support (and tests)
- support non-USD fees (paying trade fees in ETH or BNB, for example)

# Test plan:
enabled remaining test for coin/coin trades
