### PR TITLE
Lookup coin/coin prices - coin/coin pt8

### DIFF
--- a/src/yabc/costbasisreport.py
+++ b/src/yabc/costbasisreport.py
@@ -141,7 +141,7 @@ class CostBasisReport(yabc.Base):
         )
 
     def __repr__(self):
-        return "<Sold {} {} on {date} for ${}. Exchange: {exchange}. Profit:${profit}.{longterm}\n\t{trigger}>".format(
+        return "<CostBasisReport: Sold {} {} on {date} for ${}. Exchange: {exchange}. Profit:${profit}.{longterm}\n\t{trigger}>".format(
             self.quantity,
             self.asset_name,
             self.proceeds,

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -136,6 +136,7 @@ class Transaction(yabc.Base):
         quantity_traded=0,
         quantity_received=0,
         fee_symbol="USD",
+        triggering_transaction=None,
     ):
         for param in (quantity, fees, usd_subtotal):
             assert isinstance(param, (float, str, Decimal, int))
@@ -149,6 +150,7 @@ class Transaction(yabc.Base):
         self.asset_name = asset_name
         self.user_id = user_id
         self.fees = Decimal(fees)
+        self.triggering_transaction = triggering_transaction
 
         # The new syntax explicitly labels each leg of the trade.
         # Allow its use to overwrite values in columns for "asset_name" and "usd_subtotal"

--- a/testdata/adhoc/adhoc.csv
+++ b/testdata/adhoc/adhoc.csv
@@ -1,8 +1,8 @@
 ReceivedCurrency,ReceivedAmount,Timestamp,Type,TradedCurrency,TradedAmount,FeeCurrency,Fee
 BTC,3,2018/3/4,GiftReceived,USD,750,,
-,,2018/3/6 7:57PM,GiftSent,BTC,1
-BTC,0.25,2018/4/1,Mining,,,,
-USD, 1000,2018/5/1,Spending,BTC,.33,USD,15
-ETH,10001,2018/5/21,GiftReceived
+,,2018/3/6 7:57PM,GiftSent,BTC,1,,
+BTC,0.25,2018/4/1,Mining,,,,,
+USD, 1000,2018/5/1,Spending,BTC,.33,USD,15,
+ETH,10001,2018/5/21,GiftReceived,,,,
 BTC,0.33,2018/5/22,Sell,ETH,10000,BTC,.001
 BTC,15.,2018/5/24,Buy,USD,12345,USD,10

--- a/testdata/adhoc/adhoc.csv
+++ b/testdata/adhoc/adhoc.csv
@@ -1,7 +1,7 @@
 ReceivedCurrency,ReceivedAmount,Timestamp,Type,TradedCurrency,TradedAmount,FeeCurrency,Fee
-BTC,3,2018/3/4,GiftReceived,USD,750
+BTC,3,2018/3/4,GiftReceived,USD,750,,
 ,,2018/3/6 7:57PM,GiftSent,BTC,1
-BTC,0.25,2018/4/1,Mining
+BTC,0.25,2018/4/1,Mining,,,,
 USD, 1000,2018/5/1,Spending,BTC,.33,USD,15
 ETH,10001,2018/5/21,GiftReceived
 BTC,0.33,2018/5/22,Sell,ETH,10000,BTC,.001

--- a/testdata/adhoc/adhoc.csv
+++ b/testdata/adhoc/adhoc.csv
@@ -1,7 +1,7 @@
 ReceivedCurrency,ReceivedAmount,Timestamp,Type,TradedCurrency,TradedAmount,FeeCurrency,Fee
 BTC,3,2018/3/4,GiftReceived,USD,750,,
 ,,2018/3/6 7:57PM,GiftSent,BTC,1,,
-BTC,0.25,2018/4/1,Mining,,,,,
+BTC,0.25,2018/4/1,Mining,,,,
 USD, 1000,2018/5/1,Spending,BTC,.33,USD,15,
 ETH,10001,2018/5/21,GiftReceived,,,,
 BTC,0.33,2018/5/22,Sell,ETH,10000,BTC,.001

--- a/testdata/adhoc/adhoc.csv
+++ b/testdata/adhoc/adhoc.csv
@@ -2,7 +2,7 @@ ReceivedCurrency,ReceivedAmount,Timestamp,Type,TradedCurrency,TradedAmount,FeeCu
 BTC,3,2018/3/4,GiftReceived,USD,750,,
 ,,2018/3/6 7:57PM,GiftSent,BTC,1,,
 BTC,0.25,2018/4/1,Mining,,,,
-USD, 1000,2018/5/1,Spending,BTC,.33,USD,15,
+USD, 1000,2018/5/1,Spending,BTC,.33,USD,15
 ETH,10001,2018/5/21,GiftReceived,,,,
 BTC,0.33,2018/5/22,Sell,ETH,10000,BTC,.001
 BTC,15.,2018/5/24,Buy,USD,12345,USD,10

--- a/tests/basis/test_coin_to_coin.py
+++ b/tests/basis/test_coin_to_coin.py
@@ -7,7 +7,6 @@ import unittest
 from tests.transaction_utils import make_buy
 from yabc import basis
 from yabc import coinpool
-from yabc import costbasisreport
 from yabc import transaction
 
 
@@ -35,7 +34,12 @@ class CoinToCoinTest(unittest.TestCase):
         )
         self.reports = self.bp.process()
 
-    def test_trade_input_fields(self):
+    def test_coin_to_coin_pool_remnants(self):
+        """
+        The ETH/BTC trade above generates a TRADE_INPUT. Check its fields.
+
+        Also check that the ETH is gone.
+        """
         remaining_btc = self.bp.get_pool().get("BTC")[0]
         self.assertEqual(remaining_btc.quantity_received, 8)
         self.assertEqual(remaining_btc.date, datetime.datetime(2017, 1, 1))
@@ -45,18 +49,15 @@ class CoinToCoinTest(unittest.TestCase):
         self.assertEqual(remaining_btc.symbol_traded, "USD")
         self.assertEqual(remaining_btc.fee_symbol, "USD")
         self.assertEqual(remaining_btc.fees, 0)
+        self.assertEqual(len(self.bp.get_pool().get("ETH")), 0)
 
     def test_single_transaction(self):
         """
         A single coin/coin trade, following a buy. Check the results minus fees.
-
-        TODO: This fails for a couple reasons. Fix and enable it.
-            1. we can't add a coin/coin trade to a pool. We need to create TradeInputs and add them.
-            2. Without a historical price data source, we can't build CostBasisReports for coin/coin trades accurately.
         """
 
         self.assertEqual(len(self.reports), 1)
-        report = self.reports[0]  # type: costbasisreport.CostBasisReport
+        report = self.reports[0]
         daily_val = decimal.Decimal("1008.6")
         value_of_sell = 8 * daily_val
         fees = decimal.Decimal(".001") * daily_val

--- a/tests/basis/test_coin_to_coin.py
+++ b/tests/basis/test_coin_to_coin.py
@@ -33,8 +33,20 @@ class CoinToCoinTest(unittest.TestCase):
         self.bp = basis.BasisProcessor(
             coinpool.PoolMethod.FIFO, [self.buy_eth, self.sell_eth_to_btc]
         )
+        self.reports = self.bp.process()
 
-    def test_single_transation(self):
+    def test_trade_input_fields(self):
+        remaining_btc = self.bp.get_pool().get("BTC")[0]
+        self.assertEqual(remaining_btc.quantity_received, 8)
+        self.assertEqual(remaining_btc.date, datetime.datetime(2017, 1, 1))
+        self.assertEqual(remaining_btc.symbol_received, "BTC")
+        price = 1000 * decimal.Decimal("8.6")
+        self.assertEqual(remaining_btc.quantity_traded, price)
+        self.assertEqual(remaining_btc.symbol_traded, "USD")
+        self.assertEqual(remaining_btc.fee_symbol, "USD")
+        self.assertEqual(remaining_btc.fees, 0)
+
+    def test_single_transaction(self):
         """
         A single coin/coin trade, following a buy. Check the results minus fees.
 
@@ -42,10 +54,9 @@ class CoinToCoinTest(unittest.TestCase):
             1. we can't add a coin/coin trade to a pool. We need to create TradeInputs and add them.
             2. Without a historical price data source, we can't build CostBasisReports for coin/coin trades accurately.
         """
-        reports = self.bp.process()
 
-        self.assertEqual(len(reports), 1)
-        report = reports[0]  # type: costbasisreport.CostBasisReport
+        self.assertEqual(len(self.reports), 1)
+        report = self.reports[0]  # type: costbasisreport.CostBasisReport
         daily_val = decimal.Decimal("1008.6")
         value_of_sell = 8 * daily_val
         fees = decimal.Decimal(".001") * daily_val


### PR DESCRIPTION
- for coin/coin trades: make sure we add the inputs to the pool.
- Also make sure we lookup the basis when we add these inputs back.

# test plan
additional unit tests for simple coin/coin trades.