### PR TITLE
Lookup fiat prices if cost basis is absent

### DIFF
--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -223,15 +223,23 @@ def _build_sale_reports(pool, pool_index, trans, basis_information_absent, ohlc)
     """
     ans = []
     received_asset = "USD"
+    proceeds = trans.quantity_received
+    fees_in_fiat = trans.fees
+    if not is_fiat(trans.fee_symbol):
+        fees_in_fiat = ohlc.get(trans.fee_symbol, trans.date).high * trans.fees
     if not is_fiat(trans.symbol_received):
         received_asset = trans.symbol_received
+        proceeds = (
+            trans.quantity_received * ohlc.get(trans.symbol_received, trans.date).high
+            - fees_in_fiat
+        )
     if basis_information_absent:
         report = CostBasisReport(
             trans.user_id,
             decimal.Decimal(0),
             trans.quantity_traded,
             trans.date,
-            proceeds=trans.quantity_received,
+            proceeds=proceeds,
             date_sold=trans.date,
             asset=trans.symbol_traded,
             triggering_transaction=trans,

--- a/tests/basis/test_coin_to_coin_no_basis.py
+++ b/tests/basis/test_coin_to_coin_no_basis.py
@@ -1,0 +1,37 @@
+#  Copyright (c) 2019. Seattle Blockchain Solutions. All rights reserved.
+#  Licensed under the MIT License. See LICENSE in the project root for license information.
+import datetime
+import decimal
+import unittest
+
+from yabc import basis
+from yabc import coinpool
+from yabc import transaction
+
+
+class TestCoinToCoinNoBasis(unittest.TestCase):
+    def setUp(self) -> None:
+        self.date = datetime.datetime(2018, 5, 22)
+        self.tx1 = transaction.Transaction(
+            transaction.Operation.SELL,
+            date=self.date,
+            symbol_received="BTC",
+            symbol_traded="ETH",
+            quantity_received=1,
+            quantity_traded=1000,
+        )
+
+    def test_no_basis_still_looks_up_price(self):
+        """
+        The issue with self.tx1 is that there is no existing coin to sell, no ETH to trade away.
+
+        We should still look up the value of the received asset.
+        """
+        bp = basis.BasisProcessor(coinpool.PoolMethod.FIFO, [self.tx1])
+        reports = bp.process()
+        one_btc_in_fiat = decimal.Decimal("8423")
+        report = reports[0]
+        self.assertEqual(report.proceeds, one_btc_in_fiat)
+        self.assertEqual(report.adjustment, 0)
+        self.assertEqual(report.date_purchased, self.tx1.date)
+        self.assertEqual(report.date_sold, self.tx1.date)


### PR DESCRIPTION
When a coin/coin trade has no basis, we should still estimate the proceeds by looking the price of the received goods.


# test plan
ci
