### PR TITLE
Allow importing from binance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,7 @@ build: src
 	docker build --tag yabc .
 
 nuke_db_and_run:
-	rm -f src/instance/*
-	PYTHONPATH=src FLASK_APP=yabc.app FLASK_ENV=development flask init-db
-	PYTHONPATH=src FLASK_APP=yabc.app FLASK_ENV=development flask run
+	./nuke_db_and_run
 
 run:
 	PYTHONPATH=src FLASK_APP=yabc.app FLASK_ENV=development flask run
@@ -50,4 +48,4 @@ pypi_deploy:
 	TWINE_USERNAME=robertkarl python3 -m twine upload dist/* --skip-existing
 
 
-.PHONY: build test_all test_adhoc test_local test_buyone_sellone pypi_deploy
+.PHONY: build test_all test_adhoc test_local test_buyone_sellone pypi_deploy nuke_db_and_run

--- a/nuke_db_and_run
+++ b/nuke_db_and_run
@@ -1,0 +1,4 @@
+#! /usr/bin/env sh
+rm -f src/instance/*
+PYTHONPATH=src FLASK_APP=yabc.app FLASK_ENV=development flask init-db
+PYTHONPATH=src FLASK_APP=yabc.app FLASK_ENV=development flask run

--- a/src/yabc/basis.py
+++ b/src/yabc/basis.py
@@ -14,6 +14,8 @@ from yabc.costbasisreport import CostBasisReport
 from yabc.transaction import Transaction
 from yabc.transaction import is_fiat
 
+BASIS_INFORMATION_FLAG = "Transaction without basis information"
+
 __author__ = "Robert Karl <robertkarljr@gmail.com>"
 
 
@@ -144,7 +146,7 @@ def _process_one(trans, pool, ohlc_source=None):
         if pool_index >= len(curr_pool):
             # If we get here, we have partial information about the tx.
             # Use a basis of zero for the sale.
-            flags.append(("Transaction without basis information", trans))
+            flags.append((BASIS_INFORMATION_FLAG, trans))
             basis_information_absent = True
             amount = trans.quantity_traded
         else:

--- a/src/yabc/formats/__init__.py
+++ b/src/yabc/formats/__init__.py
@@ -42,7 +42,7 @@ def add_supported_exchanges():
     TODO: these are circular imports; these files then attempt to import THIS file.
     """
     from . import adhoc  # noqa
-    from . import binance # noqa
+    from . import binance  # noqa
     from . import coinbase  # noqa
     from . import gemini  # noqa
     from . import localbitcoins  # noqa

--- a/src/yabc/formats/__init__.py
+++ b/src/yabc/formats/__init__.py
@@ -39,12 +39,10 @@ FORMAT_CLASSES = []
 
 def add_supported_exchanges():
     """
-    This is in a function mostly so our automated reformatting scripts don't place these imports above all statements
-
-    #noqa should stop our unused import zapper from zapping.
+    TODO: these are circular imports; these files then attempt to import THIS file.
     """
-    # TODO: these are circular imports; these files then attemp to import THIS file.
     from . import adhoc  # noqa
+    from . import binance # noqa
     from . import coinbase  # noqa
     from . import gemini  # noqa
     from . import localbitcoins  # noqa

--- a/src/yabc/formats/binance.py
+++ b/src/yabc/formats/binance.py
@@ -67,6 +67,9 @@ class BinanceParser(Format):
     def parse(self):
         reader = DictReader(self._file)
         for line in reader:
+            for key in HEADERS:
+                if key not in line:
+                    raise RuntimeError("Not a valid binance file.")
             date = delorean.parse(line["Date"]).datetime
             market = line["Market"]
             operation = _BINANCE_TYPE_MAP[line["Type"]]

--- a/src/yabc/formats/binance.py
+++ b/src/yabc/formats/binance.py
@@ -17,6 +17,7 @@ import delorean
 
 from yabc import transaction
 from yabc.formats import Format
+from yabc.formats import FORMAT_CLASSES
 
 HEADERS = "Date,Market,Type,Price,Amount,Total,Fee,Fee Coin".split(",")
 
@@ -93,3 +94,6 @@ class BinanceParser(Format):
 
     def __iter__(self):
         return self
+
+FORMAT_CLASSES.append(BinanceParser)
+

--- a/src/yabc/formats/binance.py
+++ b/src/yabc/formats/binance.py
@@ -84,7 +84,6 @@ class BinanceParser(Format):
             )
 
     def __init__(self, file=None, filename: str = None):
-        file.seek(0)
         self._file = file
         self._reports = []
         self._filename = filename

--- a/src/yabc/formats/binance.py
+++ b/src/yabc/formats/binance.py
@@ -67,7 +67,7 @@ class BinanceParser(Format):
     def parse(self):
         reader = DictReader(self._file)
         for line in reader:
-            date = delorean.parse(line["Date"])
+            date = delorean.parse(line["Date"]).datetime
             market = line["Market"]
             operation = _BINANCE_TYPE_MAP[line["Type"]]
             amount = decimal.Decimal(line["Amount"])
@@ -81,6 +81,7 @@ class BinanceParser(Format):
             )
 
     def __init__(self, file=None, filename: str = None):
+        file.seek(0)
         self._file = file
         self._reports = []
         self._filename = filename

--- a/src/yabc/formats/binance.py
+++ b/src/yabc/formats/binance.py
@@ -16,8 +16,8 @@ from typing import Sequence
 import delorean
 
 from yabc import transaction
-from yabc.formats import Format
 from yabc.formats import FORMAT_CLASSES
+from yabc.formats import Format
 
 HEADERS = "Date,Market,Type,Price,Amount,Total,Fee,Fee Coin".split(",")
 
@@ -96,5 +96,5 @@ class BinanceParser(Format):
     def __iter__(self):
         return self
 
-FORMAT_CLASSES.append(BinanceParser)
 
+FORMAT_CLASSES.append(BinanceParser)

--- a/src/yabc/transaction_parser.py
+++ b/src/yabc/transaction_parser.py
@@ -40,6 +40,7 @@ class TransactionParser:
         # Try formats until something works.
         for constructor in yabc.formats.FORMAT_CLASSES:
             try:
+                f.seek(0)
                 generator = constructor(f)
                 values = list(generator)
                 self._exchange = constructor

--- a/tests/formats/test_binance.py
+++ b/tests/formats/test_binance.py
@@ -31,7 +31,7 @@ class BinanceCsvTest(unittest.TestCase):
 
         self.assertEqual(sell_to_eth.symbol_traded, "BTC")
         self.assertEqual(sell_to_eth.quantity_traded, 1)
-        self.assertEqual(sell_to_eth.date.date, datetime.date(2017, 1, 1))
+        self.assertEqual(sell_to_eth.date, datetime.datetime(2017, 1, 1))
         self.assertEqual(sell_to_eth.source, "binance")
 
         # For this transaction, the fee was paid as .01 ETH. Convert that to USD to get:

--- a/tests/formats/test_binance.py
+++ b/tests/formats/test_binance.py
@@ -31,7 +31,7 @@ class BinanceCsvTest(unittest.TestCase):
 
         self.assertEqual(sell_to_eth.symbol_traded, "BTC")
         self.assertEqual(sell_to_eth.quantity_traded, 1)
-        self.assertEqual(sell_to_eth.date, datetime.datetime(2017, 1, 1))
+        self.assertEqual(sell_to_eth.date, datetime.datetime(2017, 1, 1, 11, 22))
         self.assertEqual(sell_to_eth.source, "binance")
 
         # For this transaction, the fee was paid as .01 ETH. Convert that to USD to get:


### PR DESCRIPTION
closes #62 !

# Test plan
```
$ PYTHONPATH=src python -m yabc testdata/binance/binance.csv 
3 transactions to be reported

<CostBasisReport: Sold 1 BTC on 2017-01-01 11:22:00 for $1075. Exchange: binance. Profit:$1075.
	<TX 2017-01-01 11:22:00 SELL 125.0 ETH for 1 BTC, from exchange binance. Fee 0.01 ETH>>
<CostBasisReport: Sold 125.0 ETH on 2017-01-01 11:23:00 for $1009. Exchange: binance. Profit:$0.
	<TX 2017-01-01 11:23:00 SELL 1 BTC for 125 ETH, from exchange binance. Fee 0.01 ETH>>
<CostBasisReport: Sold 1 BTC on 2017-01-01 11:24:00 for $10030. Exchange: binance. Profit:$8955.
	<TX 2017-01-01 11:24:00 SELL 10030 USD for 1 BTC, from exchange binance. Fee 0.01 BTC>>

total gain or loss for above transactions: 10030

total basis for above transactions: 2084
total proceeds for above transactions: 12114
Remaining coins after sales:
<TX 2017-01-01 11:24:00 BUY 1 BTC for 10025 USD, from exchange binance. Fee 0.01 BTC>

```