### PR TITLE
Gemini date fix

### DIFF
--- a/src/yabc/formats/gemini.py
+++ b/src/yabc/formats/gemini.py
@@ -1,3 +1,4 @@
+import datetime
 import decimal
 
 import openpyxl
@@ -27,7 +28,13 @@ def _quantity(tx_row):
     supported = [(10, "BTC"), (13, "ETH"), (16, "ZEC"), (19, "BCH"), (22, "LTC")]
     for index, currency_name in supported:
         if tx_row[index].value:
-            return abs(decimal.Decimal(str(tx_row[index].value))), currency_name
+            val = tx_row[index].value
+            if isinstance(val, datetime.datetime):
+                # For some reason, for cells that have type 'n', it's possible to end up with a date here.
+                # Could be an issue with openpyxl
+                start = datetime.datetime(1900, 1, 1)
+                val = (val - start).days + 1
+            return abs(decimal.Decimal(str(val))), currency_name
     raise RuntimeError("Could not parse any cryptocurrency from Gemini row")
 
 

--- a/src/yabc/transaction.py
+++ b/src/yabc/transaction.py
@@ -211,7 +211,9 @@ class Transaction(yabc.Base):
             # Do not modify the object further if we've already restored fields.
             return
 
-        self.fee_symbol = "USD"  # Not possible to have others, until binance or other coin/coin markets are added.
+        self.fee_symbol = (
+            "USD"
+        )  # Not possible to have others, until binance or other coin/coin markets are added.
         if self.is_simple_input():
             self.symbol_received = self.asset_name
             self.quantity_received = self.quantity


### PR DESCRIPTION
Our excel parser is capable of giving us excel cells with type 'n' that are `datetime.datetime` objects.

This was causing a DecimalConversion error.

check if we get a date and diff between then and the datetime that results from an excel cell with value `1` formatted as `'d'`. That value is jan 1, 1900.

TODO: create a test case if this is an openpyxl and report a bug